### PR TITLE
Refactor runtime generation

### DIFF
--- a/src/airbridge/run.py
+++ b/src/airbridge/run.py
@@ -36,7 +36,6 @@ DEFAULT_LOCK_FILE = (
 DEFAULT_TIMEOUT = 1  # Default timeout in seconds for acquiring the lock
 
 
-src_runtime = int(datetime.now().timestamp())
 
 # Initialize a logger for the script
 logger = logging.getLogger(__name__)
@@ -218,7 +217,7 @@ class StateHandler:
         self.logger = logging.getLogger(__name__)
         self.source_config_hash = source_config_hash
 
-    def run_state_script(self) -> bool:
+    def run_state_script(self, src_runtime) -> bool:
         """Execute the state fetching and storing.
 
         Returns:
@@ -253,9 +252,9 @@ class StateHandler:
             return False
 
 
-    def execute(self) -> None:
+    def execute(self, src_runtime) -> None:
         """Execute the state-related actions."""
-        success = self.run_state_script()
+        success = self.run_state_script(src_runtime)
         if not success:
             # This log is optional, but if you want a specific log here, you can keep it
             self.logger.error("State action execution failed.")
@@ -760,7 +759,7 @@ class ImageInfo:
     dst_image: str = ""  # Destination Airbyte image
 
 
-def parse_airbyte_arguments(default_config=None) -> argparse.Namespace:
+def parse_airbyte_arguments(src_runtime, default_config=None) -> argparse.Namespace:
     """Parse command-line arguments for the Airbyte Docker Runner."""
     default_config = default_config or {}
 
@@ -831,7 +830,7 @@ def parse_airbyte_arguments(default_config=None) -> argparse.Namespace:
 
     # Generate a job ID if not provided
     args.job = args.job or f"jobid-{src_runtime}"
-    
+
     # Set the log file path
     fh = logging.FileHandler(f"{args.output_path}/out.log", "w")
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -842,7 +841,7 @@ def parse_airbyte_arguments(default_config=None) -> argparse.Namespace:
     return args
 
 
-def handle_docker(args):
+def handle_docker(args, src_runtime):
     """Set up and return the Docker handler based on provided arguments."""
     logging.info("\U0001F680 Initiating your Airbridge data workflow...")
 
@@ -868,7 +867,7 @@ def handle_docker(args):
         return None
 
 
-def handle_state(args):
+def handle_state(args, src_runtime):
     """Execute the state handler based on provided arguments."""
     try:
         executor = StateHandler(
@@ -877,7 +876,7 @@ def handle_state(args):
             source_config_hash=args.source_config_hash,
             job_id=getattr(args, "job", None),
         )
-        executor.execute()
+        executor.execute(src_runtime)
     except Exception as error:
         logging.error(
             f"Error executing state script of type {type(error)}: {error}"
@@ -901,13 +900,14 @@ def main():
             config_manager = ConfigManager(
                 config_file=getattr(temp_args, "runtime_configs", None)
             )
-            args = parse_airbyte_arguments(default_config=config_manager.config)
+            src_runtime = int(datetime.now().timestamp())
+            args = parse_airbyte_arguments(src_runtime, default_config=config_manager.config)
             config_manager.update_from_args(args)
 
-            handler = handle_docker(args)
+            handler = handle_docker(args, src_runtime)
             if handler:
                 handler.execute()
-                handle_state(args)
+                handle_state(args, src_runtime)
                 handler.final_cleanup()
                 logging.info(
                     "Your Airbridge data workflow has completed successfully! \u2728 \U0001F370 \u2728"

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -21,11 +21,10 @@ def test_handle_docker_success():
     
     # Mock src_runtime for the context of this test
     mocked_src_runtime = "test_runtime"
-    
+
     with patch("airbridge.run.AirbyteDockerHandler") as mock_handler, \
-         patch("logging.info") as mock_log_info, \
-         patch("airbridge.run.src_runtime", mocked_src_runtime):  # Mocking the src_runtime used within handle_docker
-        result = handle_docker(mock_args)
+         patch("logging.info") as mock_log_info:
+        result = handle_docker(mock_args, mocked_src_runtime)
         
     # Assert the order of log messages
     mock_log_info.assert_any_call("🚀 Initiating your Airbridge data workflow...")
@@ -46,7 +45,7 @@ def test_handle_docker_failure():
     with patch("logging.info") as mock_log_info, \
          patch("logging.error") as mock_log_error, \
          patch("airbridge.run.AirbyteDockerHandler", side_effect=Exception("Test error")):
-        result = handle_docker(mock_args)
+        result = handle_docker(mock_args, "runtime")
     
     # Adjust the expected log message
     mock_log_info.assert_called_with("A state file was passed: test_state_path")
@@ -60,7 +59,7 @@ def test_handle_state_success():
     mock_args.source_config_hash = "test_hash"
     
     with patch("airbridge.run.StateHandler") as mock_state_handler:
-        handle_state(mock_args)
+        handle_state(mock_args, "runtime")
         
     mock_state_handler.assert_called_with(
         output_path="test_output_path",
@@ -68,7 +67,7 @@ def test_handle_state_success():
         source_config_hash="test_hash",
         job_id=getattr(mock_args, "job", None),
     )
-    mock_state_handler.return_value.execute.assert_called_once()
+    mock_state_handler.return_value.execute.assert_called_once_with("runtime")
 
 def test_handle_state_failure():
     mock_args = Mock()
@@ -76,6 +75,6 @@ def test_handle_state_failure():
     with patch("airbridge.run.StateHandler", side_effect=Exception("Test error")), \
          patch("logging.error") as mock_log_error:
         with pytest.raises(RuntimeError, match="Failed executing state script."):
-            handle_state(mock_args)
+            handle_state(mock_args, "runtime")
             
     mock_log_error.assert_called_with("Error executing state script of type <class 'Exception'>: Test error")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -62,20 +62,22 @@ def test_init(state_handler):
 
 def test_run_state_script_success(state_handler):
     with patch("airbridge.run.state_main", return_value=None):  # Adjust this to the actual import path of state_main
-        assert state_handler.run_state_script() == True
+        assert state_handler.run_state_script(123) == True
 
 def test_run_state_script_failure(state_handler):
     with patch("airbridge.run.state_main", side_effect=Exception("Test exception")):  # Adjust this to the actual import path of state_main
-        assert state_handler.run_state_script() == False
+        assert state_handler.run_state_script(123) == False
 
 def test_execute_success(state_handler):
-    with patch.object(state_handler, "run_state_script", return_value=True):
-        state_handler.execute()
+    with patch.object(state_handler, "run_state_script", return_value=True) as mock_run:
+        state_handler.execute(123)
+        mock_run.assert_called_with(123)
         # Since the function logs info and doesn't return, we can only verify that no exceptions were raised.
 
 def test_execute_failure(state_handler):
-    with patch.object(state_handler, "run_state_script", return_value=False):
-        state_handler.execute()
+    with patch.object(state_handler, "run_state_script", return_value=False) as mock_run:
+        state_handler.execute(123)
+        mock_run.assert_called_with(123)
         # Again, since the function logs an error and doesn't return, we can only verify that no exceptions were raised.
 
 def test_file_read_success(tmpdir):


### PR DESCRIPTION
## Summary
- compute `src_runtime` in `main()`
- pass runtime value to `parse_airbyte_arguments`, `handle_docker`, and `handle_state`
- update `StateHandler` interface to accept runtime
- adapt tests to new signatures

## Testing
- `pytest -q` *(fails: command not found)*